### PR TITLE
feat: Implement hierarchical UI for NMOS resources

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "axios": "^1.6.8",
+        "axios": "^1.9.0",
         "cors": "^2.8.5",
         "express": "^4.19.2",
         "uuid": "^9.0.1",
@@ -62,7 +62,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
       "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
-      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "axios": "^1.6.8",
+    "axios": "^1.9.0",
     "cors": "^2.8.5",
     "express": "^4.19.2",
     "uuid": "^9.0.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,11 +8,17 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@fortawesome/free-solid-svg-icons": "^6.7.2",
+        "@fortawesome/react-fontawesome": "^0.2.2",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-tooltip": "^5.28.0",
+        "websocket": "^1.0.35"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
+        "@testing-library/jest-dom": "^6.4.8",
+        "@testing-library/react": "^16.0.0",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
@@ -20,8 +26,16 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^16.0.0",
-        "vite": "^6.3.5"
+        "jsdom": "^24.1.1",
+        "vite": "^6.3.5",
+        "vitest": "^2.0.5"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.3.tgz",
+      "integrity": "sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==",
+      "dev": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -36,6 +50,25 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -261,6 +294,15 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
+      "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -317,6 +359,116 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
+      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.3.tgz",
+      "integrity": "sha512-XBG3talrhid44BY1x3MHzUx/aTG8+x/Zi57M4aTKK9RFB4aLlF3TTSzfzn8nWVHWL3FgAXAxmupmDd6VWww+pw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.9.tgz",
+      "integrity": "sha512-wILs5Zk7BU86UArYBJTPy/FMPPKVKHMj1ycCEyf3VUptol0JNRLFU/BZsJ4aiIHJEbSLiizzRrw8Pc1uAEDrXw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/css-calc": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.4.tgz",
+      "integrity": "sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.3.tgz",
+      "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -898,6 +1050,71 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.0.tgz",
+      "integrity": "sha512-FRdBLykrPPA6P76GGGqlex/e7fbe0F1ykgxHYNXQsH/iTEtjMj/f9bpY5oQqbjt5VgZvgz/uKXbGuROijh3VLA==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.0.tgz",
+      "integrity": "sha512-lGTor4VlXcesUMh1cupTUTDoCxMb0V6bm3CnxHzQcw8Eaf1jQbgQX4i02fYgT0vJ82tb5MZ4CZk1LRGkktJCzg==",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+      "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+      "peer": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
+      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1297,6 +1514,99 @@
         "win32"
       ]
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
+      "integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
+      "dev": true,
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "lodash": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1396,6 +1706,86 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -1419,6 +1809,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1434,6 +1833,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -1458,6 +1867,30 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1510,6 +1943,40 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bufferutil": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.9.tgz",
+      "integrity": "sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1541,6 +2008,22 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+      "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1557,6 +2040,20 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -1577,6 +2074,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1607,12 +2116,62 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true
+    },
+    "node_modules/cssstyle": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.3.1.tgz",
+      "integrity": "sha512-ZgW+Jgdd7i52AaLYCriF8Mxqft0gD/R9i9wi6RWBhs1pqdPEzPjym7rvRKi397WmQFf3SlyUsszhw+VVCbx79Q==",
+      "dev": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.1.2",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -1632,6 +2191,21 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "dev": true
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1639,12 +2213,151 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.155",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.155.tgz",
       "integrity": "sha512-ps5KcGGmwL8VaeJlvlDlu4fORQpv3+GIcF5I3f9tUKUlJ/wsysh6HU8P5L1XWRYeXfA0oJd4PyM8ds8zTFf6Ng==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
+      "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es5-ext": {
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
+      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+      "dependencies": {
+        "d": "^1.0.2",
+        "ext": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.4",
@@ -1824,6 +2537,20 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/espree": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
@@ -1878,6 +2605,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1886,6 +2622,32 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
+      "integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "dependencies": {
+        "type": "^2.7.2"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1975,6 +2737,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1990,6 +2767,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -1998,6 +2784,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -2026,6 +2849,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2034,6 +2869,95 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -2073,6 +2997,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2096,6 +3029,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2107,7 +3051,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -2121,6 +3064,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "dev": true,
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -2210,12 +3193,35 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
+      "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
+      "dev": true
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -2225,6 +3231,64 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -2273,12 +3337,41 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
+      "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
+      "dev": true
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2343,6 +3436,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2361,6 +3466,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -2422,6 +3542,61 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2431,6 +3606,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
     },
     "node_modules/react": {
       "version": "19.1.0",
@@ -2453,6 +3634,13 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -2462,6 +3650,38 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/react-tooltip": {
+      "version": "5.28.1",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.28.1.tgz",
+      "integrity": "sha512-ZA4oHwoIIK09TS7PvSLFcRlje1wGZaxw6xHvfrzn6T82UcMEfEmHVCad16Gnr4NDNDh93HyN037VK4HDi5odfQ==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1",
+        "classnames": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -2513,6 +3733,30 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -2552,6 +3796,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2560,6 +3810,30 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -2588,6 +3862,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
@@ -2605,6 +3897,65 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
+      "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/type": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ=="
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -2616,6 +3967,23 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -2657,6 +4025,28 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/vite": {
@@ -2734,6 +4124,1133 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.19",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
+      "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.19",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
+      "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/websocket": {
+      "version": "1.0.35",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.35.tgz",
+      "integrity": "sha512-/REy6amwPZl44DDzvRCkaI1q1bIiQB0mEFQLUrhz3z2EK91cp3n72rAjUlrTP0zV22HJIUOVHQGPxhFRjxjt+Q==",
+      "dependencies": {
+        "bufferutil": "^4.0.1",
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.63",
+        "typedarray-to-buffer": "^3.1.5",
+        "utf-8-validate": "^5.0.2",
+        "yaeti": "^0.0.6"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/websocket/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/websocket/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2750,6 +5267,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -2758,6 +5291,51 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
+    },
+    "node_modules/yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "engines": {
+        "node": ">=0.10.32"
       }
     },
     "node_modules/yallist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -26,6 +27,10 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/jest-dom": "^6.4.8",
+    "vitest": "^2.0.5",
+    "jsdom": "^24.1.1"
   }
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,463 +1,290 @@
-/* Gorgeous Dark Theme - App Specific Styles */
-
-/* App-wide variables (can override :root from index.css if needed for App scope) */
-:root {
-  /* Re-affirming some, or defining app-specific ones if they differ from base */
-  --app-background: var(--base-background);
-  --app-text-color: var(--base-text);
-  --app-primary-accent: var(--accent-primary);
-  --app-secondary-accent: var(--accent-secondary);
-  --app-card-background: var(--card-background);
-  --app-border-color: var(--border-subtle);
-  --app-input-background: var(--input-background);
-  --app-input-border: var(--border-subtle); /* Can be slightly different for inputs */
-  --app-button-stop-background: #E53E3E; /* Specific red for stop/destructive */
-  --app-button-stop-hover: #C53030;    /* Darker red for hover */
+/* General App Styles */
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: #f4f7f6;
+  color: #333;
 }
 
 .App-container {
-  max-width: 1300px; 
+  max-width: 1200px;
   margin: 0 auto;
-  padding: 30px 40px; 
-  background-color: var(--app-background);
-  color: var(--app-text-color);
-  min-height: 100vh;
+  padding: 20px;
 }
 
 .App-header {
-  text-align: center;
-  margin-bottom: 40px; 
-  padding-bottom: 25px; 
-  border-bottom: 2px solid var(--app-primary-accent); 
+  background-color: #ffffff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  margin-bottom: 20px;
 }
 
 .App-header h1 {
-  /* Inherits h1 style from index.css, but can be overridden */
-  font-size: 2.75em; /* Slightly larger for main app title */
-  color: var(--app-text-color); /* Ensure it uses app text color */
+  color: #0056b3;
+  margin: 0 0 15px 0;
+  text-align: center;
 }
 
 .registry-control {
   display: flex;
-  gap: 15px; 
-  margin-bottom: 30px; 
-  align-items: center;
-  flex-wrap: wrap; /* Allow wrapping on smaller screens */
-}
-
-.registry-control label {
-  font-weight: 600; 
-  color: var(--app-secondary-accent);
-  font-size: 1.05em; /* Slightly larger label */
-}
-
-/* Consistent Input Styling */
-.registry-input, 
-.search-input, 
-.filter-select, 
-.receiver-select {
-  flex-grow: 1;
-  padding: 12px 15px; 
-  border: 1px solid var(--app-input-border);
-  border-radius: 8px; 
-  font-size: 1em;
-  background-color: var(--app-input-background);
-  color: var(--app-text-color);
-  transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
-  min-height: 48px; /* Consistent height */
-  box-sizing: border-box;
-}
-
-.registry-input:focus, 
-.search-input:focus, 
-.filter-select:focus, 
-.receiver-select:focus {
-  outline: none;
-  border-color: var(--app-primary-accent);
-  box-shadow: 0 0 0 3px var(--shadow-color-primary); /* Teal glow */
-}
-
-.stop-button {
-  background-color: var(--app-button-stop-background);
-  color: #FFFFFF; /* White text on red */
-  /* Inherits general button padding, font-weight, border-radius from index.css */
-}
-
-.stop-button:hover:not(:disabled) {
-  background-color: var(--app-button-stop-hover);
-  transform: translateY(-2px); /* Consistent lift */
-  box-shadow: 0 4px 8px rgba(229, 62, 62, 0.3); /* Reddish shadow */
-}
-.stop-button:focus-visible {
-   box-shadow: 0 0 0 3px var(--base-background), 0 0 0 5px var(--app-button-stop-background);
-}
-
-
-/* Message Styling */
-.message {
-  padding: 15px 20px; 
-  margin-bottom: 25px;
-  border-radius: 8px;
-  font-weight: 500; 
-  border: 1px solid transparent;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  transition: opacity 0.3s ease, transform 0.3s ease;
-}
-.message .fa-icon { /* If FontAwesome is used within messages */
-  margin-right: 8px;
-}
-
-.message.error {
-  background-color: var(--error-background); 
-  color: var(--error-text); 
-  border-color: var(--app-button-stop-background); /* Use a more vibrant error color for border */
-}
-
-.message.status { /* For success messages */
-  background-color: var(--success-background); 
-  color: var(--success-text); 
-  border-color: var(--accent-primary); /* Teal border for success */
-}
-
-.message.loading { /* General info/loading messages */
-  background-color: var(--card-background); 
-  color: var(--app-secondary-accent); 
-  border-color: var(--app-secondary-accent);
-}
-
-
-.resource-container {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(380px, 1fr)); 
-  gap: 25px; 
-}
-
-.resource-section h2 {
-  /* Inherits h2 from index.css */
-  margin-bottom: 20px;
-  border-bottom: 1px solid var(--app-border-color);
-  padding-bottom: 12px;
-}
-
-.resource-grid {
-  display: grid; /* This might be redundant if device-group is the direct child */
-  gap: 20px; 
-}
-
-/* Card animation */
-@keyframes fadeInCard {
-  from {
-    opacity: 0;
-    transform: translateY(10px) scale(0.98);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-.resource-card {
-  background-color: var(--app-card-background);
-  border: 1px solid var(--app-border-color);
-  border-radius: 12px; 
-  padding: 20px 24px; /* Adjusted padding */
-  box-shadow: 0 6px 12px -2px var(--shadow-color-cards), 0 4px 8px -4px rgba(0,0,0,0.1);
-  display: flex;
-  flex-direction: column;
-  transition: transform 0.25s ease-out, box-shadow 0.25s ease-out;
-  
-  /* Animation part */
-  animation: fadeInCard 0.4s ease-in-out forwards;
-  opacity: 0; /* Start transparent for animation */
-}
-/* Stagger animation for multiple cards - can be complex, but a slight delay per item helps */
-.device-group .resource-card:nth-child(1) { animation-delay: 0.05s; }
-.device-group .resource-card:nth-child(2) { animation-delay: 0.1s; }
-.device-group .resource-card:nth-child(3) { animation-delay: 0.15s; }
-/* Add more if needed, or use JS for dynamic stagger */
-
-
-.resource-card:hover {
-  transform: translateY(-5px) scale(1.02); 
-  box-shadow: 0 10px 20px -3px var(--shadow-color-cards), 0 6px 12px -4px rgba(0,0,0,0.15);
-}
-
-.resource-card h3 {
-  /* Inherits h3 from index.css */
-  margin-top: 0;
-  margin-bottom: 15px; 
-  font-size: 1.4em; /* Fine-tune card title size */
-  font-weight: 600;
-  display: flex; /* For icon alignment */
-  align-items: center;
-  gap: 8px; /* Space between icon and text */
-}
-.resource-card h3 .fa-icon {
-  color: var(--app-primary-accent); /* Ensure icon uses accent */
-}
-
-
-.resource-details p {
-  margin: 8px 0; 
-  font-size: 0.95em; 
-  line-height: 1.65; /* Improved line height */
-  word-break: break-all;
-  color: var(--app-text-color);
-  font-family: 'Roboto', 'Arial', sans-serif; /* Keep specified font if desired */
-}
-.resource-details p strong { /* For emphasizing parts like "ID:" */
-  color: var(--app-secondary-accent);
-  font-weight: 500;
-}
-
-
-.connection-control {
-  margin-top: 20px; 
-  padding-top: 15px; 
-  border-top: 1px solid var(--app-input-border); 
-}
-.connection-control .receiver-select { /* Ensure select inside card is full width */
-  width: 100%;
-  margin-bottom: 10px; /* Space if there's a button below */
-}
-
-
-.active-route { /* Style for card when it's an active route */
-  border-color: var(--app-primary-accent) !important; 
-  box-shadow: 0 0 12px var(--shadow-color-primary), 0 8px 16px -4px var(--shadow-color-cards);
-}
-.active-route h3 .fa-icon {
-  color: var(--success-text) !important; /* Green icon for active route */
-}
-
-
-.search-filter {
-  display: flex;
-  align-items: center;
-  gap: 15px; 
-  margin-bottom: 30px; 
   flex-wrap: wrap;
-  background-color: var(--app-card-background); 
-  padding: 20px 25px;
-  border-radius: 12px;
-  box-shadow: 0 4px 10px -2px var(--shadow-color-cards);
-}
-
-
-.subscription-status {
-  display: flex;
+  gap: 10px;
   align-items: center;
-  gap: 8px; 
-  margin-top: 12px; 
-}
-
-.status-indicator {
-  width: 14px; 
-  height: 14px; 
-  border-radius: 50%;
-  border: 1px solid rgba(0,0,0,0.3); 
-  transition: background-color 0.3s ease, box-shadow 0.3s ease;
-}
-
-.status-indicator.connected {
-  background-color: #38A169; /* Vibrant green */
-  box-shadow: 0 0 10px #38A169, 0 0 5px #38A169 inset;
-}
-
-.status-indicator.disconnected {
-  background-color: #E53E3E; /* Vibrant red */
-  box-shadow: 0 0 10px #E53E3E, 0 0 5px #E53E3E inset;
-}
-
-.status-indicator.error {
-  background-color: #DD6B20; /* Vibrant orange for error/warning */
-  box-shadow: 0 0 10px #DD6B20, 0 0 5px #DD6B20 inset;
-}
-
-.status-text {
-  font-size: 0.9em;
-  font-weight: 500;
-  color: var(--app-text-color);
-}
-
-
-/* Connection animation */
-.connection-animation {
-  animation: connect 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94); 
-}
-@keyframes connect { /* Subtle scale and fade */
-  0% { opacity: 0.5; transform: scale(0.95); }
-  100% { opacity: 1; transform: scale(1); }
-}
-
-
-/* Notification */
-.notification {
-  position: fixed;
-  top: 25px;
-  right: 25px;
-  background-color: var(--app-secondary-accent); 
-  color: var(--base-background); 
-  padding: 14px 22px;
-  border-radius: 8px;
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.35);
-  animation: fadeInOut 3.5s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-  z-index: 1000;
-  font-weight: 500;
-}
-@keyframes fadeInOut { /* Smooth fade in and out */
-  0% { opacity: 0; transform: translateY(-20px) scale(0.95); }
-  10% { opacity: 1; transform: translateY(0) scale(1); }
-  90% { opacity: 1; transform: translateY(0) scale(1); }
-  100% { opacity: 0; transform: translateY(-20px) scale(0.95); }
-}
-
-
-/* Highlight effect */
-.highlight {
-  animation: highlight 1.2s ease-in-out;
-}
-@keyframes highlight {
-  0%, 100% { background-color: transparent; }
-  50% { background-color: var(--shadow-color-primary); } /* Subtle teal highlight */
-}
-
-
-/* Pagination Controls Styling */
-.pagination-controls {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-top: 30px; 
   margin-bottom: 15px;
 }
 
-.pagination-controls button {
-  /* Uses global button style from index.css for base */
-  background-color: var(--app-input-background); 
-  color: var(--app-text-color); 
-  border: 1px solid var(--app-input-border); 
-  padding: 10px 18px; 
-  margin: 0 6px; 
-  /* border-radius is inherited */
-  /* font-weight is inherited */
-  /* transition is inherited */
+.registry-control label {
+  font-weight: bold;
+  margin-right: 5px;
 }
 
-.pagination-controls button:hover:not(:disabled) {
-  background-color: var(--app-primary-accent); 
-  color: var(--base-background); 
-  border-color: var(--app-primary-accent);
-  transform: translateY(-2px); /* Consistent lift */
+.registry-input {
+  flex-grow: 1;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1em;
+  min-width: 250px; /* Ensure input is not too small */
 }
 
-.pagination-controls button.active {
-  background-color: var(--app-primary-accent); 
-  color: var(--base-background); 
-  font-weight: 700; 
-  border-color: var(--app-primary-accent);
-  box-shadow: 0 0 10px var(--shadow-color-primary); 
+.action-button {
+  padding: 10px 15px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1em;
+  transition: background-color 0.3s ease;
+  color: #ffffff;
 }
 
-.pagination-controls button:disabled {
-  background-color: var(--app-border-color); 
-  color: var(--app-secondary-accent);
-  opacity: 0.6; /* More pronounced disabled state */
-  /* transform: none is inherited */
+.discover-button {
+  background-color: #007bff; /* Blue */
+}
+.discover-button:hover {
+  background-color: #0056b3;
+}
+.discover-button:disabled {
+  background-color: #cccccc;
+  cursor: not-allowed;
 }
 
-
-/* Grouping Styles */
-.device-group {
-  margin-bottom: 25px; 
-  padding: 20px; 
-  border: 1px solid var(--app-border-color); 
-  border-radius: 10px; 
-  background-color: rgba(var(--base-text-rgb, 226, 232, 240), 0.02); /* Subtle background tint for group */
-  transition: background-color 0.2s ease, border-color 0.2s ease;
+.stop-button {
+  background-color: #dc3545; /* Red */
 }
-.device-group:last-child {
-  margin-bottom: 0;
+.stop-button:hover {
+  background-color: #c82333;
 }
-.device-group:hover {
-  border-color: var(--app-secondary-accent);
-}
-
-.group-heading {
-  /* Inherits h4 from index.css */
-  margin-top: 0; /* Adjusted space above the heading */
-  margin-bottom: 20px; 
-  padding-bottom: 12px; 
-  border-bottom: 2px solid var(--app-primary-accent); 
-  display: inline-block; 
-  padding-right: 15px; 
+.stop-button:disabled {
+  background-color: #cccccc;
+  cursor: not-allowed;
 }
 
 
-/* Responsive Design Adjustments */
-@media (max-width: 992px) { 
-  .resource-container {
-    grid-template-columns: 1fr; /* Single column for tablets */
-  }
+/* Messages and Notifications */
+.message {
+  padding: 10px;
+  margin: 10px 0;
+  border-radius: 4px;
+  text-align: center;
 }
 
+.error {
+  background-color: #f8d7da;
+  color: #721c24;
+  border: 1px solid #f5c6cb;
+}
+
+.loading {
+  background-color: #e2e3e5;
+  color: #383d41;
+}
+
+.notification {
+  background-color: #d4edda;
+  color: #155724;
+  padding: 10px;
+  margin-top: 10px;
+  border-radius: 4px;
+  border: 1px solid #c3e6cb;
+}
+
+/* Resource Display - General Cards */
+.resource-card {
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 15px;
+  margin: 10px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  transition: box-shadow 0.3s ease;
+  width: calc(100% - 20px); /* Full width on small screens, adjusts in grid */
+  box-sizing: border-box;
+}
+
+.resource-card:hover {
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+.resource-card h3 {
+  margin-top: 0;
+  color: #0056b3;
+  font-size: 1.1em;
+  display: flex;
+  align-items: center;
+}
+
+.resource-details p {
+  margin: 5px 0;
+  font-size: 0.9em;
+  word-break: break-all; /* Prevent long IDs from breaking layout */
+}
+
+.connection-control {
+  margin-top: 15px;
+}
+
+.receiver-select {
+  width: 100%;
+  padding: 8px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  font-size: 0.9em;
+}
+
+.active-route {
+  border-left: 5px solid #28a745; /* Green border for active */
+}
+.active-route-text {
+  color: #28a745;
+  font-weight: bold;
+}
+
+.highlight {
+  animation: highlight-animation 1s ease-out;
+}
+
+@keyframes highlight-animation {
+  0% { background-color: #fff3cd; } /* Light yellow */
+  100% { background-color: #ffffff; }
+}
+
+.error-card {
+  border-left: 5px solid #dc3545; /* Red border for error cards */
+  background-color: #f8d7da;
+}
+
+/* Hierarchical Display Styles */
+.nodes-container {
+  margin-top: 20px;
+}
+
+.node-display {
+  background-color: #e9ecef; /* Light grey background for nodes */
+  border: 1px solid #ced4da;
+  border-radius: 8px;
+  padding: 20px;
+  margin-bottom: 20px;
+}
+
+.node-label {
+  color: #495057;
+  margin-top: 0;
+  border-bottom: 2px solid #adb5bd;
+  padding-bottom: 10px;
+}
+
+.device-display {
+  background-color: #f8f9fa; /* Slightly lighter grey for devices */
+  border: 1px solid #dee2e6;
+  border-radius: 6px;
+  padding: 15px;
+  margin-top: 15px;
+  margin-left: 20px; /* Indentation for devices */
+}
+
+.device-label {
+  color: #007bff;
+  margin-top: 0;
+  border-bottom: 1px solid #cce5ff;
+  padding-bottom: 8px;
+}
+
+.senders-section, .receivers-section {
+  margin-top: 15px;
+  padding-left: 10px; /* Indent senders/receivers under device */
+}
+
+.senders-section h4, .receivers-section h4 {
+  color: #6c757d;
+  font-size: 1.1em;
+  margin-bottom: 10px;
+}
+
+.resource-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); /* Responsive grid for cards */
+  gap: 15px;
+}
+
+.sender-card, .receiver-card {
+  /* Specific card styles can be added if needed, defaults to .resource-card */
+}
+
+.embedded-flow-details {
+  border-top: 1px dashed #eee;
+  margin-top: 10px;
+  padding-top: 10px;
+}
+
+.embedded-flow-details h4 {
+  margin-top: 0;
+  font-size: 0.95em;
+  color: #343a40;
+}
+
+.empty-state-message {
+  font-style: italic;
+  color: #6c757d;
+  padding: 10px;
+  text-align: center;
+}
+
+/* Tooltip styles */
+[data-tooltip-id^="tooltip-"] {
+  background-color: #333 !important; /* Example: ensure high contrast */
+  color: #fff !important;
+  border-radius: 4px !important;
+  padding: 5px 10px !important;
+  font-size: 0.85em !important;
+}
+
+/* Ensure FontAwesome icons are vertically aligned with text */
+.App-header h1 svg,
+.resource-card h3 svg,
+.message svg {
+  margin-right: 8px;
+  vertical-align: middle; /* Helps align icons with text */
+}
+
+/* Responsive adjustments */
 @media (max-width: 768px) {
-  .App-container {
-    padding: 20px; 
-  }
-  .App-header h1 {
-    font-size: 2.25em; /* Adjust title size */
-  }
-  .registry-control, .search-filter {
+  .registry-control {
     flex-direction: column;
-    align-items: stretch; 
+    align-items: stretch;
   }
-  .registry-input, .search-input, .filter-select, .receiver-select,
-  .registry-control button, .search-filter button { /* Full width for controls */
-    width: 100%;
-    margin-bottom: 15px;
-  }
-  .registry-control button:last-child, .search-filter button:last-child {
-    margin-bottom: 0;
-  }
-  
-  button, .stop-button, .pagination-controls button { /* General button sizing for touch */
-    padding: 12px 18px;
-    font-size: 1.05em;
-    min-height: 48px; 
-  }
-  .pagination-controls {
-    flex-wrap: wrap; /* Allow pagination buttons to wrap */
-    gap: 8px;
-  }
-}
 
-@media (max-width: 480px) {
-  .App-container {
-    padding: 15px;
+  .registry-input, .action-button {
+    width: 100%;
+    box-sizing: border-box; /* Ensure padding and border don't cause overflow */
   }
-  .App-header h1 {
-    font-size: 1.8em;
+
+  .device-display {
+    margin-left: 10px; /* Reduce indentation on smaller screens */
   }
-  .resource-card {
-    padding: 15px; 
-  }
-  .resource-card h3 {
-    font-size: 1.25em;
-  }
-  .resource-details p {
-    font-size: 0.9em;
-  }
-  .search-filter {
-    padding: 15px;
-  }
-  .message {
-    padding: 12px 15px;
-    font-size: 0.95em;
-  }
-  .group-heading {
-    font-size: 1.05em;
+
+  .resource-grid {
+    grid-template-columns: 1fr; /* Single column on very small screens */
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,53 +1,34 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'; // Added useMemo
+import { useState, useEffect, useCallback } from 'react'; // Removed useMemo
 import './App.css';
 import NmosSubscription from './components/NmosSubscription.jsx';
+import NodeDisplay from './components/NodeDisplay.jsx'; // Import NodeDisplay
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSatelliteDish, faBroadcastTower, faLink, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
-import { Tooltip } from 'react-tooltip';
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
+// Removed unused icons: faSatelliteDish, faBroadcastTower, faLink from App.jsx as they are now in cards
 
 function App() {
-  const [senders, setSenders] = useState([]);
-  const [receivers, setReceivers] = useState([]);
+  const [senders, setSenders] = useState([]); // Still needed for handleConnect dropdown
+  const [receivers, setReceivers] = useState([]); // Still needed for handleConnect dropdown and activeRoutes
+  const [nodes, setNodes] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
-  const [registryUrl, setRegistryUrl] = useState(''); // Default, user can change
+  const [registryUrl, setRegistryUrl] = useState('');
   const [activeRoutes, setActiveRoutes] = useState({});
   const [notification, setNotification] = useState('');
   const [highlight, setHighlight] = useState('');
 
-  // Pagination state (assuming this was added in a previous step as per problem context)
-  const [currentSendersPage, setCurrentSendersPage] = useState(1);
-  const [sendersPerPage] = useState(6); // Example value
-  const [currentReceiversPage, setCurrentReceiversPage] = useState(1);
-  const [receiversPerPage] = useState(6); // Example value
-
-  // Memoized senders for pagination
-  const currentSenders = useMemo(() => {
-    const indexOfLastSender = currentSendersPage * sendersPerPage;
-    const indexOfFirstSender = indexOfLastSender - sendersPerPage;
-    return senders.slice(indexOfFirstSender, indexOfLastSender);
-  }, [senders, currentSendersPage, sendersPerPage]);
-
-  // Memoized receivers for pagination
-  const currentReceivers = useMemo(() => {
-    const indexOfLastReceiver = currentReceiversPage * receiversPerPage;
-    const indexOfFirstReceiver = indexOfLastReceiver - receiversPerPage;
-    return receivers.slice(indexOfFirstReceiver, indexOfLastReceiver);
-  }, [receivers, currentReceiversPage, receiversPerPage]);
-  
-  // const filteredReceivers = receivers; // This was a temporary fix, now using currentReceivers
-
   const fetchResources = useCallback(async (isRefresh = false, customUrl = null) => {
     setIsLoading(true);
     setError(null);
+    // Nodes, Senders, Receivers will be reset here before fetching
+    setNodes([]);
+    setSenders([]);
+    setReceivers([]);
     const urlToUse = customUrl || registryUrl;
     if (!urlToUse || (!urlToUse.startsWith('http://') && !urlToUse.startsWith('https://'))) {
       setError('无效的注册表URL。必须以http://或https://开头');
       setIsLoading(false);
-      setSenders([]);
-      setReceivers([]);
-      setCurrentSendersPage(1); // Reset pagination
-      setCurrentReceiversPage(1); // Reset pagination
+      // Already reset states at the beginning of the function
       return;
     }
 
@@ -55,9 +36,7 @@ function App() {
       const apiUrl = '/api/is04/discover';
       const response = await fetch(apiUrl, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ registryUrl: urlToUse }),
       });
 
@@ -66,248 +45,169 @@ function App() {
         throw new Error(errorData.message || `HTTP错误！状态：${response.status}`);
       }
       const data = await response.json();
-      const resources = data.data;
-
-      // console.log structures were here for verification, removing them now.
       
-      setSenders(resources.senders || []);
-      setReceivers(resources.receivers || []);
-      setCurrentSendersPage(1); // Reset pagination
-      setCurrentReceiversPage(1); // Reset pagination
+      if (data.data && data.data.nodes) {
+        setNodes(data.data.nodes);
+
+        // Create flat lists for senders and receivers for SenderCard dropdown and activeRoutes logic
+        let flatSenders = [];
+        let flatReceivers = [];
+        data.data.nodes.forEach(node => {
+          if (node.devices && Array.isArray(node.devices)) {
+            node.devices.forEach(device => {
+              if (device.senders && Array.isArray(device.senders)) {
+                flatSenders.push(...device.senders);
+              }
+              if (device.receivers && Array.isArray(device.receivers)) {
+                flatReceivers.push(...device.receivers);
+              }
+            });
+          }
+        });
+        setSenders(flatSenders); // Used by SenderCard for dropdown
+        setReceivers(flatReceivers); // Used by SenderCard for dropdown & for activeRoutes logic
+      } else {
+        // States already reset if structure is not as expected
+        console.warn("API response did not contain expected nodes structure:", data);
+      }
+      
       alert(data.message || '资源获取成功！');
       setError(null);
     } catch (e) {
       console.error("获取IS-04资源失败：", e);
       setError(`加载资源失败：${e.message}。请确保后端正在运行且NMOS_REGISTRY_URL可被后端访问。`);
-      setSenders([]);
-      setReceivers([]);
-      setCurrentSendersPage(1); // Reset pagination
-      setCurrentReceiversPage(1); // Reset pagination
+      // States already reset at the beginning or if data.data.nodes is missing
     }
     setIsLoading(false);
-  }, [registryUrl, sendersPerPage, receiversPerPage]); // Added pagination setters to dependencies
+  }, [registryUrl]); // Removed pagination dependencies
 
   useEffect(() => {
-    // if (registryUrl) fetchResources(false, registryUrl); // Keep manual trigger
+    // if (registryUrl) fetchResources(false, registryUrl); // Manual trigger is preferred
   }, [registryUrl, fetchResources]);
+
 
   const handleStopConnection = async () => {
     setIsLoading(true);
     setError(null);
+    setNodes([]); // Clear nodes immediately
+    setSenders([]);
+    setReceivers([]);
     setNotification('正在尝试停止与注册表的连接...');
 
     try {
-      const response = await fetch('/api/nmos/stop-registry', {
-        method: 'POST',
-      });
-
+      const response = await fetch('/api/nmos/stop-registry', { method: 'POST' });
       const result = await response.json();
 
       if (!response.ok) {
         throw new Error(result.message || `停止连接失败，状态：${response.status}`);
       }
-
       setNotification(result.message || '成功停止与注册表的连接。');
-      setSenders([]);
-      setReceivers([]);
-      setCurrentSendersPage(1); // Reset pagination
-      setCurrentReceiversPage(1); // Reset pagination
+      // States already cleared at the beginning of this function
     } catch (e) {
       console.error("停止连接失败：", e);
       setError(`停止连接错误：${e.message}`);
-      setNotification(''); 
+      // States should have been cleared already, but ensure UI consistency if error occurs mid-process
+      setNodes([]);
+      setSenders([]);
+      setReceivers([]);
+      setNotification('');
     }
     setIsLoading(false);
   };
 
   const handleDiscover = () => {
-    fetchResources(true, registryUrl); 
+    fetchResources(false, registryUrl); // isRefresh is not strictly needed now but kept for consistency
   };
 
   const handleConnect = async (senderId, receiverId) => {
-    console.log(`Attempting to connect sender ${senderId} to receiver ${receiverId}`); // Added log
+    console.log(`Attempting to connect sender ${senderId} to receiver ${receiverId}`);
     if (!senderId || !receiverId) {
       alert('请选择发送端和接收端。');
       return;
     }
-    setNotification(`正在尝试将发送端${senderId}连接到接收端${receiverId}...`);
+    setNotification(`正在尝试将发送端 ${senderId} 连接到接收端 ${receiverId}...`);
 
     try {
-      const response = await fetch('/api/is05/connections', { // Modified URL
+      const response = await fetch('/api/is05/connections', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ senderId, receiverId }),
       });
-
       const result = await response.json();
-
       if (!response.ok) {
         throw new Error(result.message || `连接失败，状态：${response.status}`);
       }
-
-      setNotification(`成功将发送端${senderId}连接到接收端${receiverId}。接收端响应：${JSON.stringify(result.receiverResponse, null, 2)}`);
+      setNotification(`成功将发送端 ${senderId} 连接到接收端 ${receiverId}。接收端响应：${JSON.stringify(result.receiverResponse, null, 2)}`);
       setActiveRoutes(prev => ({ ...prev, [senderId]: { receiverId } }));
       setHighlight(receiverId);
-      setTimeout(() => setHighlight(''), 1000);
+      setTimeout(() => setHighlight(''), 1000); // Highlight for 1 second
     } catch (e) {
       console.error("连接失败：", e);
       setError(`连接错误：${e.message}`);
-      setNotification(''); 
+      setNotification('');
     }
   };
 
   const handleSubscriptionUpdate = (topic, changes) => {
-    // 处理订阅更新
     console.log('Subscription update:', topic, changes);
-    // 这里可以添加更多逻辑来处理更新
+    // Future: Implement logic to update nodes/devices/senders/receivers based on WebSocket messages
+    // This might involve re-fetching or intelligently merging changes.
+    // For now, a simple re-fetch on significant updates might be an option,
+    // or more granular updates if the backend provides detailed change info.
   };
-
-  // Pagination functions (assuming these were added in a previous step)
-  const paginateSenders = (pageNumber) => setCurrentSendersPage(pageNumber);
-  const paginateReceivers = (pageNumber) => setCurrentReceiversPage(pageNumber);
-
-  // PaginationControls component (assuming this was added in a previous step)
-  const PaginationControls = ({ currentPage, totalPages, paginate, type }) => {
-    if (totalPages <= 1) return null;
-    const pageNumbers = [];
-    for (let i = 1; i <= totalPages; i++) pageNumbers.push(i);
-    return (
-      <div className="pagination-controls">
-        <button onClick={() => paginate(currentPage - 1)} disabled={currentPage === 1}>上一页</button>
-        {pageNumbers.map(number => (
-          <button key={`${type}-${number}`} onClick={() => paginate(number)} className={currentPage === number ? 'active' : ''}>{number}</button>
-        ))}
-        <button onClick={() => paginate(currentPage + 1)} disabled={currentPage === totalPages}>下一页</button>
-      </div>
-    );
-  };
-
-  // Grouping Function
-  const groupResourcesByDevice = (resourcesList) => { // Renamed 'resources' to 'resourcesList'
-    if (!resourcesList) return {};
-    return resourcesList.reduce((acc, resource) => {
-      const deviceId = resource.device_id || 'unknown_device'; // Fallback for safety
-      if (!acc[deviceId]) {
-        acc[deviceId] = [];
-      }
-      acc[deviceId].push(resource);
-      return acc;
-    }, {});
-  };
-
-  // Apply Grouping to Paginated Data
-  const groupedSenders = useMemo(() => groupResourcesByDevice(currentSenders), [currentSenders]);
-  const groupedReceivers = useMemo(() => groupResourcesByDevice(currentReceivers), [currentReceivers]);
-
 
   return (
     <div className="App-container">
       <header className="App-header">
         <h1>Vega-NMOS控制面板</h1>
         <div className="registry-control">
-          <label htmlFor="registryUrl">NMOS注册表URL（查询API v1.x）：</label>
-          <input 
-            type="text" 
-            id="registryUrl" 
+          <label htmlFor="registryUrl">NMOS注册表URL：</label>
+          <input
+            type="text"
+            id="registryUrl"
             value={registryUrl}
             onChange={(e) => setRegistryUrl(e.target.value)}
-            placeholder="例如：http://0.11.1.14:8010/x-nmos/query/v1.3"
+            placeholder="例如：http://localhost:8080" // Example placeholder
             className="registry-input"
           />
-          <button onClick={handleDiscover} disabled={isLoading || !registryUrl} style={{ backgroundColor: '#007BFF', color: '#FFFFFF', border: 'none', padding: '10px 20px', borderRadius: '4px', cursor: 'pointer', fontSize: '1em', minHeight: '44px' }}>
+          <button 
+            onClick={handleDiscover} 
+            disabled={isLoading || !registryUrl} 
+            className="action-button discover-button"
+          >
             {isLoading ? '正在发现...' : '发现/刷新资源'}
           </button>
-          <button onClick={handleStopConnection} disabled={isLoading} className="stop-button">停止连接注册表</button>
+          <button 
+            onClick={handleStopConnection} 
+            disabled={isLoading} 
+            className="action-button stop-button"
+          >
+            停止连接注册表
+          </button>
         </div>
         <NmosSubscription onUpdate={handleSubscriptionUpdate} />
       </header>
+      
       {error && <p className="message error"><FontAwesomeIcon icon={faExclamationTriangle} /> {error}</p>}
       {notification && <div className="notification">{notification}</div>}
       {isLoading && !error && <p className="message loading">正在加载资源...</p>}
-      <div className="resource-container">
-        <div className="resource-section">
-          <h2><FontAwesomeIcon icon={faBroadcastTower} /> 发送端 ({senders.length})</h2>
-          {senders.length === 0 && !isLoading && <p>未发现发送端。</p>}
-          {senders.length > 0 && Object.keys(groupedSenders).length === 0 && currentSenders.length > 0 && !isLoading && <p>当前页没有发送端。</p>}
-          {senders.length > 0 && Object.keys(groupedSenders).length === 0 && currentSenders.length === 0 && !isLoading && <p>当前页没有发送端 (可能是由于翻页到了空页)。</p>}
 
-          <div className="resource-grid">
-            {Object.entries(groupedSenders).map(([deviceId, sendersInGroup]) => (
-              <div key={deviceId} className="device-group">
-                <h4 className="group-heading">Device: {deviceId}</h4>
-                {sendersInGroup.map((sender) => (
-                  <div key={sender.id} className="resource-card">
-                    <h3><FontAwesomeIcon icon={faBroadcastTower} style={{ color: '#28a745' }} /> {sender.label || '未命名发送端'}</h3>
-                    <div className="resource-details">
-                      <p data-tooltip-id={`tooltip-sender-${sender.id}`}>ID: {sender.id}</p>
-                      <Tooltip id={`tooltip-sender-${sender.id}`} place="top" content={`发送端ID: ${sender.id}`} />
-                      <p>Flow ID: {sender.flow_id}</p>
-                      <p>Transport: {sender.transport}</p>
-                    </div>
-                    {receivers.length > 0 && (
-                      <div className="connection-control">
-                        <select 
-                          onChange={(e) => e.target.value && handleConnect(sender.id, e.target.value)} 
-                          defaultValue=""
-                          className="receiver-select"
-                        >
-                          <option value="" disabled>选择接收端进行连接...</option>
-                          {receivers.map(receiver => (
-                            <option key={receiver.id} value={receiver.id}>
-                              {receiver.label || `接收端 ${receiver.id}`}
-                            </option>
-                          ))}
-                        </select>
-                        {/* Removed the direct connect button for clarity */}
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            ))}
-          </div>
-          <PaginationControls 
-            currentPage={currentSendersPage} 
-            totalPages={Math.ceil(senders.length / sendersPerPage)} 
-            paginate={paginateSenders}
-            type="senders"
+      <div className="nodes-container">
+        {nodes.length === 0 && !isLoading && !error && (
+          <p className="empty-state-message">
+            {registryUrl ? '未发现节点。请确保注册表URL正确且可访问。' : '请输入注册表URL并点击发现资源。'}
+          </p>
+        )}
+        {nodes.map(node => (
+          <NodeDisplay
+            key={node.id}
+            node={node}
+            allReceivers={receivers} // Pass flat list of all receivers for SenderCard dropdown
+            handleConnect={handleConnect}
+            activeRoutes={activeRoutes}
+            highlight={highlight}
           />
-        </div>
-
-        <div className="resource-section">
-          <h2><FontAwesomeIcon icon={faSatelliteDish} /> 接收端 ({receivers.length})</h2>
-          {receivers.length === 0 && !isLoading && <p>未发现接收端。</p>}
-          {receivers.length > 0 && Object.keys(groupedReceivers).length === 0 && currentReceivers.length > 0 && !isLoading && <p>当前页没有接收端。</p>}
-          {receivers.length > 0 && Object.keys(groupedReceivers).length === 0 && currentReceivers.length === 0 && !isLoading && <p>当前页没有接收端 (可能是由于翻页到了空页)。</p>}
-          
-          <div className="resource-grid">
-            {Object.entries(groupedReceivers).map(([deviceId, receiversInGroup]) => (
-              <div key={deviceId} className="device-group">
-                <h4 className="group-heading">Device: {deviceId}</h4>
-                {receiversInGroup.map((receiver) => (
-                  <div key={receiver.id} className={`resource-card ${Object.values(activeRoutes).some(route => route.receiverId === receiver.id) ? 'active-route' : ''} ${highlight === receiver.id ? 'highlight' : ''}`}>
-                    <h3><FontAwesomeIcon icon={faSatelliteDish} style={{ color: Object.values(activeRoutes).some(route => route.receiverId === receiver.id) ? '#28a745' : '#dc3545' }} /> {receiver.label || '未命名接收端'}</h3>
-                    <div className="resource-details">
-                      <p data-tooltip-id={`tooltip-receiver-${receiver.id}`}>ID: {receiver.id}</p>
-                      <Tooltip id={`tooltip-receiver-${receiver.id}`} place="top" content={`接收端ID: ${receiver.id}`} />
-                      <p>Format: {receiver.format}</p>
-                      <p>Capabilities: {JSON.stringify(receiver.caps, null, 2)}</p> {/* Corrected 'Caps' to 'Capabilities' for consistency if needed, or keep as 'Caps' if that's the actual data */}
-                      {Object.values(activeRoutes).some(route => route.receiverId === receiver.id) && <p>活动路由来自: {Object.keys(activeRoutes).find(key => activeRoutes[key].receiverId === receiver.id)}</p>}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            ))}
-          </div>
-          <PaginationControls 
-            currentPage={currentReceiversPage} 
-            totalPages={Math.ceil(receivers.length / receiversPerPage)} 
-            paginate={paginateReceivers}
-            type="receivers"
-          />
-        </div>
+        ))}
       </div>
     </div>
   );

--- a/frontend/src/components/DeviceDisplay.jsx
+++ b/frontend/src/components/DeviceDisplay.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import SenderCard from './SenderCard';
+import ReceiverCard from './ReceiverCard';
+import { Tooltip } from 'react-tooltip';
+
+const DeviceDisplay = ({ device, allReceivers, handleConnect, activeRoutes, highlight }) => {
+  if (!device) {
+    return <div className="device-display error-card">Device data is missing.</div>;
+  }
+
+  return (
+    <div className="device-display">
+      <h3 className="device-label" data-tooltip-id={`tooltip-device-${device.id}`}>
+        Device: {device.label || 'Unnamed Device'} (ID: {device.id.substring(0,8)}...)
+      </h3>
+      <Tooltip id={`tooltip-device-${device.id}`} place="top" content={`Device ID: ${device.id}\nNode ID: ${device.node_id}`} />
+      
+      {(!device.senders || device.senders.length === 0) && (!device.receivers || device.receivers.length === 0) && (
+        <p className="empty-state-message">This device has no senders or receivers.</p>
+      )}
+
+      {device.senders && device.senders.length > 0 && (
+        <div className="senders-section">
+          <h4>Senders ({device.senders.length})</h4>
+          <div className="resource-grid">
+            {device.senders.map(sender => (
+              <SenderCard 
+                key={sender.id} 
+                sender={sender} 
+                allReceivers={allReceivers} 
+                handleConnect={handleConnect} 
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {device.receivers && device.receivers.length > 0 && (
+        <div className="receivers-section">
+          <h4>Receivers ({device.receivers.length})</h4>
+          <div className="resource-grid">
+            {device.receivers.map(receiver => (
+              <ReceiverCard 
+                key={receiver.id} 
+                receiver={receiver} 
+                isActive={activeRoutes && Object.values(activeRoutes).some(route => route.receiverId === receiver.id)}
+                highlight={highlight === receiver.id}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DeviceDisplay;

--- a/frontend/src/components/DeviceDisplay.test.jsx
+++ b/frontend/src/components/DeviceDisplay.test.jsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import DeviceDisplay from './DeviceDisplay';
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock child components
+vi.mock('./SenderCard', () => ({
+  default: (props) => <div data-testid={`sender-card-${props.sender.id}`}>{props.sender.label}</div>
+}));
+vi.mock('./ReceiverCard', () => ({
+  default: (props) => <div data-testid={`receiver-card-${props.receiver.id}`}>{props.receiver.label}</div>
+}));
+vi.mock('react-tooltip', () => ({
+  Tooltip: (props) => <div data-testid={`tooltip-${props.id}`}>{props.content}</div>
+}));
+
+describe('DeviceDisplay', () => {
+  const mockDevice = {
+    id: 'device-abc',
+    label: 'Test Device',
+    node_id: 'node-xyz',
+    senders: [
+      { id: 'sender-1', label: 'Sender 1' },
+      { id: 'sender-2', label: 'Sender 2' },
+    ],
+    receivers: [
+      { id: 'receiver-1', label: 'Receiver 1' },
+    ],
+  };
+
+  const mockAllReceivers = [{ id: 'receiver-1', label: 'Receiver 1' }];
+  const mockHandleConnect = vi.fn();
+  const mockActiveRoutes = {};
+
+  it('renders without crashing with minimal props', () => {
+    render(
+      <DeviceDisplay 
+        device={mockDevice} 
+        allReceivers={mockAllReceivers} 
+        handleConnect={mockHandleConnect} 
+        activeRoutes={mockActiveRoutes} 
+      />
+    );
+    expect(screen.getByText(`Device: ${mockDevice.label} (ID: ${mockDevice.id.substring(0,8)}...)`)).toBeInTheDocument();
+  });
+
+  it('renders device information correctly', () => {
+    render(
+      <DeviceDisplay 
+        device={mockDevice} 
+        allReceivers={mockAllReceivers} 
+        handleConnect={mockHandleConnect}
+        activeRoutes={mockActiveRoutes} 
+      />
+    );
+    expect(screen.getByText(`Device: ${mockDevice.label} (ID: ${mockDevice.id.substring(0,8)}...)`)).toBeInTheDocument();
+    // Check for tooltip content as well
+    expect(screen.getByTestId(`tooltip-tooltip-device-${mockDevice.id}`)).toHaveTextContent(`Device ID: ${mockDevice.id}`);
+    expect(screen.getByTestId(`tooltip-tooltip-device-${mockDevice.id}`)).toHaveTextContent(`Node ID: ${mockDevice.node_id}`);
+  });
+
+  it('renders the correct number of SenderCard components', () => {
+    render(
+      <DeviceDisplay 
+        device={mockDevice} 
+        allReceivers={mockAllReceivers} 
+        handleConnect={mockHandleConnect} 
+        activeRoutes={mockActiveRoutes} 
+      />
+    );
+    expect(screen.getByText('Senders (2)')).toBeInTheDocument();
+    expect(screen.getByTestId('sender-card-sender-1')).toBeInTheDocument();
+    expect(screen.getByTestId('sender-card-sender-2')).toBeInTheDocument();
+  });
+
+  it('renders the correct number of ReceiverCard components', () => {
+    render(
+      <DeviceDisplay 
+        device={mockDevice} 
+        allReceivers={mockAllReceivers} 
+        handleConnect={mockHandleConnect} 
+        activeRoutes={mockActiveRoutes} 
+      />
+    );
+    expect(screen.getByText('Receivers (1)')).toBeInTheDocument();
+    expect(screen.getByTestId('receiver-card-receiver-1')).toBeInTheDocument();
+  });
+  
+  it('renders "no senders or receivers" message if both are empty', () => {
+    const deviceWithoutSendersOrReceivers = { ...mockDevice, senders: [], receivers: [] };
+    render(
+      <DeviceDisplay 
+        device={deviceWithoutSendersOrReceivers} 
+        allReceivers={mockAllReceivers} 
+        handleConnect={mockHandleConnect} 
+        activeRoutes={mockActiveRoutes} 
+      />
+    );
+    expect(screen.getByText('This device has no senders or receivers.')).toBeInTheDocument();
+  });
+
+  it('renders "no senders" message if only senders are empty', () => {
+    const deviceWithoutSenders = { ...mockDevice, senders: [] };
+    render(
+      <DeviceDisplay 
+        device={deviceWithoutSenders} 
+        allReceivers={mockAllReceivers} 
+        handleConnect={mockHandleConnect} 
+        activeRoutes={mockActiveRoutes} 
+      />
+    );
+    expect(screen.queryByText('Senders (0)')).not.toBeInTheDocument(); // Section header might not render
+    expect(screen.getByText('Receivers (1)')).toBeInTheDocument();
+  });
+
+
+  it('renders error message if device data is missing', () => {
+    render(
+      <DeviceDisplay 
+        device={null} 
+        allReceivers={mockAllReceivers} 
+        handleConnect={mockHandleConnect} 
+        activeRoutes={mockActiveRoutes} 
+      />
+    );
+    expect(screen.getByText('Device data is missing.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/NodeDisplay.jsx
+++ b/frontend/src/components/NodeDisplay.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import DeviceDisplay from './DeviceDisplay';
+import { Tooltip } from 'react-tooltip';
+
+const NodeDisplay = ({ node, allReceivers, handleConnect, activeRoutes, highlight }) => {
+  if (!node) {
+    return <div className="node-display error-card">Node data is missing.</div>;
+  }
+
+  return (
+    <div className="node-display">
+      <h2 className="node-label" data-tooltip-id={`tooltip-node-${node.id}`}>
+        Node: {node.label || 'Unnamed Node'} (ID: {node.id.substring(0,8)}...)
+      </h2>
+      <Tooltip id={`tooltip-node-${node.id}`} place="top" content={`Node ID: ${node.id}\nAPI Endpoints: ${node.api?.endpoints.map(ep => `${ep.protocol}://${ep.host}:${ep.port}`).join(', ')}`} />
+
+      {(!node.devices || node.devices.length === 0) && (
+        <p className="empty-state-message">This node has no devices.</p>
+      )}
+
+      {node.devices && node.devices.map(device => (
+        <DeviceDisplay 
+          key={device.id} 
+          device={device} 
+          allReceivers={allReceivers} 
+          handleConnect={handleConnect}
+          activeRoutes={activeRoutes}
+          highlight={highlight}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default NodeDisplay;

--- a/frontend/src/components/NodeDisplay.test.jsx
+++ b/frontend/src/components/NodeDisplay.test.jsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import NodeDisplay from './NodeDisplay';
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock child component
+vi.mock('./DeviceDisplay', () => ({
+  default: (props) => <div data-testid={`device-display-${props.device.id}`}>{props.device.label}</div>
+}));
+vi.mock('react-tooltip', () => ({
+  Tooltip: (props) => <div data-testid={`tooltip-${props.id}`}>{props.content}</div>
+}));
+
+describe('NodeDisplay', () => {
+  const mockNode = {
+    id: 'node-xyz',
+    label: 'Test Node',
+    api: {
+      endpoints: [
+        { protocol: 'http', host: 'localhost', port: 8080 }
+      ]
+    },
+    devices: [
+      { id: 'device-1', label: 'Device 1' },
+      { id: 'device-2', label: 'Device 2' },
+    ],
+  };
+  const mockAllReceivers = [];
+  const mockHandleConnect = vi.fn();
+  const mockActiveRoutes = {};
+
+  it('renders without crashing with minimal props', () => {
+    render(
+      <NodeDisplay 
+        node={mockNode} 
+        allReceivers={mockAllReceivers} 
+        handleConnect={mockHandleConnect} 
+        activeRoutes={mockActiveRoutes} 
+      />
+    );
+    expect(screen.getByText(`Node: ${mockNode.label} (ID: ${mockNode.id.substring(0,8)}...)`)).toBeInTheDocument();
+  });
+
+  it('renders node information correctly', () => {
+    render(
+      <NodeDisplay 
+        node={mockNode} 
+        allReceivers={mockAllReceivers} 
+        handleConnect={mockHandleConnect} 
+        activeRoutes={mockActiveRoutes} 
+      />
+    );
+    expect(screen.getByText(`Node: ${mockNode.label} (ID: ${mockNode.id.substring(0,8)}...)`)).toBeInTheDocument();
+    // Check for tooltip content as well
+    expect(screen.getByTestId(`tooltip-tooltip-node-${mockNode.id}`)).toHaveTextContent(`Node ID: ${mockNode.id}`);
+    expect(screen.getByTestId(`tooltip-tooltip-node-${mockNode.id}`)).toHaveTextContent(`API Endpoints: http://localhost:8080`);
+
+  });
+
+  it('renders the correct number of DeviceDisplay components', () => {
+    render(
+      <NodeDisplay 
+        node={mockNode} 
+        allReceivers={mockAllReceivers} 
+        handleConnect={mockHandleConnect} 
+        activeRoutes={mockActiveRoutes} 
+      />
+    );
+    expect(screen.getByTestId('device-display-device-1')).toBeInTheDocument();
+    expect(screen.getByTestId('device-display-device-2')).toBeInTheDocument();
+    expect(screen.getByText('Device 1')).toBeInTheDocument(); // Check for mocked content
+    expect(screen.getByText('Device 2')).toBeInTheDocument(); // Check for mocked content
+  });
+
+  it('renders "no devices" message if devices array is empty', () => {
+    const nodeWithoutDevices = { ...mockNode, devices: [] };
+    render(
+      <NodeDisplay 
+        node={nodeWithoutDevices} 
+        allReceivers={mockAllReceivers} 
+        handleConnect={mockHandleConnect} 
+        activeRoutes={mockActiveRoutes} 
+      />
+    );
+    expect(screen.getByText('This node has no devices.')).toBeInTheDocument();
+  });
+  
+  it('renders error message if node data is missing', () => {
+    render(
+      <NodeDisplay 
+        node={null} 
+        allReceivers={mockAllReceivers} 
+        handleConnect={mockHandleConnect} 
+        activeRoutes={mockActiveRoutes} 
+      />
+    );
+    expect(screen.getByText('Node data is missing.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ReceiverCard.jsx
+++ b/frontend/src/components/ReceiverCard.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSatelliteDish } from '@fortawesome/free-solid-svg-icons';
+import { Tooltip } from 'react-tooltip'; // Assuming react-tooltip is a project dependency
+
+const ReceiverCard = ({ receiver, isActive, highlight }) => {
+  if (!receiver) {
+    return <div className="resource-card error-card">Receiver data is missing.</div>;
+  }
+
+  // Determine icon color based on active state
+  const iconColor = isActive ? '#28a745' : '#dc3545'; // Green if active, red if not
+
+  return (
+    <div className={`resource-card receiver-card ${isActive ? 'active-route' : ''} ${highlight ? 'highlight' : ''}`}>
+      <h3>
+        <FontAwesomeIcon icon={faSatelliteDish} style={{ color: iconColor, marginRight: '8px' }} />
+        {receiver.label || 'Unnamed Receiver'}
+      </h3>
+      <div className="resource-details">
+        <p data-tooltip-id={`tooltip-receiver-${receiver.id}`}>ID: {receiver.id}</p>
+        <Tooltip id={`tooltip-receiver-${receiver.id}`} place="top" content={`Receiver ID: ${receiver.id}`} />
+        {receiver.format && <p>Format: {receiver.format}</p>}
+        {receiver.caps && Object.keys(receiver.caps).length > 0 && (
+          <p>Capabilities: {JSON.stringify(receiver.caps)}</p>
+        )}
+        {/* Add other relevant receiver details here */}
+        {isActive && <p className="active-route-text">Currently Active</p>}
+      </div>
+    </div>
+  );
+};
+
+export default ReceiverCard;

--- a/frontend/src/components/ReceiverCard.test.jsx
+++ b/frontend/src/components/ReceiverCard.test.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ReceiverCard from './ReceiverCard';
+import { describe, it, expect } from 'vitest';
+
+// Mock FontAwesomeIcon and Tooltip as they are external dependencies not relevant to component logic
+vi.mock('@fortawesome/react-fontawesome', () => ({
+  FontAwesomeIcon: (props) => <i className={`fa ${props.icon.iconName}`} />
+}));
+vi.mock('react-tooltip', () => ({
+  Tooltip: (props) => <div data-testid={`tooltip-${props.id}`}>{props.content}</div>
+}));
+
+describe('ReceiverCard', () => {
+  const mockReceiver = {
+    id: 'receiver-123',
+    label: 'Test Receiver',
+    format: 'video/H264',
+    caps: { media_types: ['video/raw'] },
+  };
+
+  it('renders without crashing with minimal props', () => {
+    render(<ReceiverCard receiver={mockReceiver} />);
+    expect(screen.getByText('Test Receiver')).toBeInTheDocument();
+  });
+
+  it('renders receiver information correctly', () => {
+    render(<ReceiverCard receiver={mockReceiver} />);
+    expect(screen.getByText('Test Receiver')).toBeInTheDocument();
+    expect(screen.getByText(`ID: ${mockReceiver.id}`)).toBeInTheDocument();
+    expect(screen.getByText(`Format: ${mockReceiver.format}`)).toBeInTheDocument();
+    expect(screen.getByText(`Capabilities: ${JSON.stringify(mockReceiver.caps)}`)).toBeInTheDocument();
+  });
+
+  it('displays active state when isActive is true', () => {
+    render(<ReceiverCard receiver={mockReceiver} isActive={true} />);
+    expect(screen.getByText('Currently Active')).toBeInTheDocument();
+    // Check for 'active-route' class if your CSS uses it for styling active state
+    const cardElement = screen.getByText('Test Receiver').closest('.receiver-card');
+    expect(cardElement).toHaveClass('active-route');
+  });
+
+  it('does not display active state when isActive is false or undefined', () => {
+    render(<ReceiverCard receiver={mockReceiver} />);
+    expect(screen.queryByText('Currently Active')).not.toBeInTheDocument();
+    const cardElement = screen.getByText('Test Receiver').closest('.receiver-card');
+    expect(cardElement).not.toHaveClass('active-route');
+  });
+  
+  it('applies highlight class when highlight is true', () => {
+    render(<ReceiverCard receiver={mockReceiver} highlight={true} />);
+    const cardElement = screen.getByText('Test Receiver').closest('.receiver-card');
+    expect(cardElement).toHaveClass('highlight');
+  });
+
+  it('renders error message if receiver data is missing', () => {
+    render(<ReceiverCard receiver={null} />);
+    expect(screen.getByText('Receiver data is missing.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/SenderCard.jsx
+++ b/frontend/src/components/SenderCard.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faBroadcastTower } from '@fortawesome/free-solid-svg-icons';
+import { Tooltip } from 'react-tooltip'; // Assuming react-tooltip is a project dependency
+
+const SenderCard = ({ sender, allReceivers, handleConnect }) => {
+  if (!sender) {
+    return <div className="resource-card error-card">Sender data is missing.</div>;
+  }
+
+  return (
+    <div className="resource-card sender-card">
+      <h3>
+        <FontAwesomeIcon icon={faBroadcastTower} style={{ color: '#28a745', marginRight: '8px' }} />
+        {sender.label || 'Unnamed Sender'}
+      </h3>
+      <div className="resource-details">
+        <p data-tooltip-id={`tooltip-sender-${sender.id}`}>ID: {sender.id}</p>
+        <Tooltip id={`tooltip-sender-${sender.id}`} place="top" content={`Sender ID: ${sender.id}`} />
+        {sender.flow_id && <p>Flow ID: {sender.flow_id}</p>}
+        {sender.transport && <p>Transport: {sender.transport}</p>}
+        {/* Display embedded flow details if available */}
+        {sender.flow && (
+          <div className="embedded-flow-details">
+            <h4>Flow Details:</h4>
+            <p>Format: {sender.flow.format}</p>
+            {/* Add other relevant flow details here */}
+          </div>
+        )}
+      </div>
+      {allReceivers && allReceivers.length > 0 && (
+        <div className="connection-control">
+          <select
+            onChange={(e) => e.target.value && handleConnect(sender.id, e.target.value)}
+            defaultValue=""
+            className="receiver-select"
+          >
+            <option value="" disabled>Connect to Receiver...</option>
+            {allReceivers.map(receiver => (
+              <option key={receiver.id} value={receiver.id}>
+                {receiver.label || `Receiver ${receiver.id.substring(0,8)}...`}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SenderCard;

--- a/frontend/src/components/SenderCard.test.jsx
+++ b/frontend/src/components/SenderCard.test.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SenderCard from './SenderCard';
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock FontAwesomeIcon and Tooltip
+vi.mock('@fortawesome/react-fontawesome', () => ({
+  FontAwesomeIcon: (props) => <i className={`fa ${props.icon.iconName}`} />
+}));
+vi.mock('react-tooltip', () => ({
+  Tooltip: (props) => <div data-testid={`tooltip-${props.id}`}>{props.content}</div>
+}));
+
+describe('SenderCard', () => {
+  const mockSender = {
+    id: 'sender-456',
+    label: 'Test Sender',
+    flow_id: 'flow-789',
+    transport: 'urn:nmos:transport:rtp.mcast',
+    flow: {
+      format: 'video/jxsv',
+      media_type: 'video',
+    },
+  };
+
+  const mockReceivers = [
+    { id: 'receiver-1', label: 'Receiver 1' },
+    { id: 'receiver-2', label: 'Receiver 2' },
+  ];
+
+  const mockHandleConnect = vi.fn();
+
+  it('renders without crashing with minimal props', () => {
+    render(<SenderCard sender={mockSender} allReceivers={mockReceivers} handleConnect={mockHandleConnect} />);
+    expect(screen.getByText('Test Sender')).toBeInTheDocument();
+  });
+
+  it('renders sender information correctly', () => {
+    render(<SenderCard sender={mockSender} allReceivers={mockReceivers} handleConnect={mockHandleConnect} />);
+    expect(screen.getByText('Test Sender')).toBeInTheDocument();
+    expect(screen.getByText(`ID: ${mockSender.id}`)).toBeInTheDocument();
+    expect(screen.getByText(`Flow ID: ${mockSender.flow_id}`)).toBeInTheDocument();
+    expect(screen.getByText(`Transport: ${mockSender.transport}`)).toBeInTheDocument();
+  });
+
+  it('renders embedded flow details if flow is present', () => {
+    render(<SenderCard sender={mockSender} allReceivers={mockReceivers} handleConnect={mockHandleConnect} />);
+    expect(screen.getByText('Flow Details:')).toBeInTheDocument();
+    expect(screen.getByText(`Format: ${mockSender.flow.format}`)).toBeInTheDocument();
+  });
+
+  it('does not render flow details if flow is not present', () => {
+    const senderWithoutFlow = { ...mockSender, flow: null };
+    render(<SenderCard sender={senderWithoutFlow} allReceivers={mockReceivers} handleConnect={mockHandleConnect} />);
+    expect(screen.queryByText('Flow Details:')).not.toBeInTheDocument();
+  });
+
+  it('renders connection dropdown if receivers are present', () => {
+    render(<SenderCard sender={mockSender} allReceivers={mockReceivers} handleConnect={mockHandleConnect} />);
+    const selectInput = screen.getByRole('combobox');
+    expect(selectInput).toBeInTheDocument();
+    expect(screen.getByText('Connect to Receiver...')).toBeInTheDocument(); // Default option
+    expect(screen.getByText('Receiver 1')).toBeInTheDocument();
+    expect(screen.getByText('Receiver 2')).toBeInTheDocument();
+  });
+
+  it('does not render connection dropdown if no receivers are present', () => {
+    render(<SenderCard sender={mockSender} allReceivers={[]} handleConnect={mockHandleConnect} />);
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+  });
+
+  it('calls handleConnect when a receiver is selected from dropdown', () => {
+    render(<SenderCard sender={mockSender} allReceivers={mockReceivers} handleConnect={mockHandleConnect} />);
+    const selectInput = screen.getByRole('combobox');
+    fireEvent.change(selectInput, { target: { value: 'receiver-1' } });
+    expect(mockHandleConnect).toHaveBeenCalledWith(mockSender.id, 'receiver-1');
+  });
+
+  it('renders error message if sender data is missing', () => {
+    render(<SenderCard sender={null} allReceivers={mockReceivers} handleConnect={mockHandleConnect} />);
+    expect(screen.getByText('Sender data is missing.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -1,0 +1,2 @@
+// src/test/setup.js
+import '@testing-library/jest-dom';

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
@@ -14,5 +15,10 @@ export default defineConfig({
         // rewrite: (path) => path.replace(/^\/api/, ''), // Optional: if backend doesn't expect /api prefix
       }
     }
-  }
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.js', // Optional: if you need setup files
+  },
 })


### PR DESCRIPTION
This commit introduces a hierarchical (layered) view for NMOS resources in the frontend, allowing you to browse nodes, their devices, and the senders/receivers within those devices.

Key changes:

Backend:
- Modified the `/api/is04/discover` endpoint to fetch and return a hierarchical structure of NMOS resources: nodes -> devices -> senders/receivers. Senders now include embedded flow information.

Frontend:
- Updated `App.jsx` to fetch and manage the hierarchical data using a new `nodes` state.
- Introduced new components for displaying the hierarchy:
    - `NodeDisplay.jsx`: Renders a node and its devices.
    - `DeviceDisplay.jsx`: Renders a device and its senders/receivers.
    - `SenderCard.jsx`: Displays sender details and connection options.
    - `ReceiverCard.jsx`: Displays receiver details.
- Removed previous pagination and device-based grouping in favor of the new hierarchical display.
- Maintained flat lists of senders and receivers in `App.jsx` to support the existing connection logic in `SenderCard.jsx`.
- Added basic CSS for the new hierarchical layout.
- Added unit tests for the new components (`NodeDisplay`, `DeviceDisplay`, `SenderCard`, `ReceiverCard`) using Vitest and React Testing Library.
- Configured the Vitest testing environment.

This change addresses the issue requirement to show NMOS registry info in layers (node/device/sender or receiver), significantly enhancing the UI/UX for browsing NMOS resources.